### PR TITLE
Fixed retrieving complex types

### DIFF
--- a/Magic.IndexedDb/Helpers/ManagerHelper.cs
+++ b/Magic.IndexedDb/Helpers/ManagerHelper.cs
@@ -1,11 +1,6 @@
 ﻿using Magic.IndexedDb.SchemaAnnotations;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 
 namespace Magic.IndexedDb.Helpers
 {
@@ -74,7 +69,7 @@ namespace Magic.IndexedDb.Helpers
             return propertyMappings;
         }
 
-        public static object? GetValueFromValueKind(object value)
+        public static object? GetValueFromValueKind(object value, Type type)
         {
             if (value is JsonElement jsonElement)
             {
@@ -84,7 +79,7 @@ namespace Magic.IndexedDb.Helpers
                     JsonValueKind.String => jsonElement.GetString(),
                     JsonValueKind.True => true,
                     JsonValueKind.False => false,
-                    _ => null
+                    _ => jsonElement.Deserialize(type)
                 };
             }
 

--- a/Magic.IndexedDb/IndexDbManager.cs
+++ b/Magic.IndexedDb/IndexDbManager.cs
@@ -496,9 +496,9 @@ namespace Magic.IndexedDb
                     if (propertyMappings.TryGetValue(kvp.Key, out var propertyName))
                     {
                         var property = recordType.GetProperty(propertyName);
-                        var value = ManagerHelper.GetValueFromValueKind(kvp.Value);
                         if (property != null)
                         {
+                            var value = ManagerHelper.GetValueFromValueKind(kvp.Value, property.PropertyType);
                             property.SetValue(record, ConvertValueToType(value!, property.PropertyType));
                         }
                     }
@@ -520,9 +520,9 @@ namespace Magic.IndexedDb
                 if (propertyMappings.TryGetValue(kvp.Key, out var propertyName))
                 {
                     var property = recordType.GetProperty(propertyName);
-                    var value = ManagerHelper.GetValueFromValueKind(kvp.Value);
                     if (property != null)
                     {
+                        var value = ManagerHelper.GetValueFromValueKind(kvp.Value, property.PropertyType);
                         property.SetValue(record, ConvertValueToType(value!, property.PropertyType));
                     }
                 }


### PR DESCRIPTION
I was trying to use `List` and `Dictionary` types in my entities and found that they saved correctly, but errored when I tried to retrieve them.  This fixes that issue and should handle any complex type.