### PR TITLE
OpenAsync

### DIFF
--- a/Magic.IndexedDb/Extensions/ServiceCollectionExtensions.cs
+++ b/Magic.IndexedDb/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Magic.IndexedDb.Factories;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 using System.Collections.Generic;

--- a/Magic.IndexedDb/Factories/EncryptionFactory.cs
+++ b/Magic.IndexedDb/Factories/EncryptionFactory.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using static System.Runtime.InteropServices.JavaScript.JSType;
 
-namespace Magic.IndexedDb
+namespace Magic.IndexedDb.Factories
 {
     public sealed class EncryptionFactory(IndexedDbManager indexDbManager) : IEncryptionFactory
     {

--- a/Magic.IndexedDb/Factories/IMagicDbFactory.cs
+++ b/Magic.IndexedDb/Factories/IMagicDbFactory.cs
@@ -2,7 +2,13 @@ namespace Magic.IndexedDb
 {
     public interface IMagicDbFactory
     {
+        [Obsolete("Use OpenRegisteredAsync instead.")]
         Task<IndexedDbManager> GetDbManagerAsync(string dbName);
+        [Obsolete("Use OpenRegisteredAsync instead.")]
+        Task<IndexedDbManager> GetDbManagerAsync(DbStore dbStore);
+
         ValueTask<IndexedDbManager> OpenAsync(DbStore dbStore, bool force = false, CancellationToken cancellationToken = default);
+        IndexedDbManager Get(string dbName);
+        ValueTask<IndexedDbManager> GetRegisteredAsync(string dbName, CancellationToken cancellationToken = default);
     }
 }

--- a/Magic.IndexedDb/Factories/IMagicDbFactory.cs
+++ b/Magic.IndexedDb/Factories/IMagicDbFactory.cs
@@ -1,11 +1,8 @@
-using System.Threading.Tasks;
-
 namespace Magic.IndexedDb
 {
     public interface IMagicDbFactory
     {
         Task<IndexedDbManager> GetDbManagerAsync(string dbName);
-
-        Task<IndexedDbManager> GetDbManagerAsync(DbStore dbStore);
+        ValueTask<IndexedDbManager> OpenAsync(DbStore dbStore, bool force = false, CancellationToken cancellationToken = default);
     }
 }

--- a/Magic.IndexedDb/IndexDbManager.cs
+++ b/Magic.IndexedDb/IndexDbManager.cs
@@ -2,6 +2,7 @@ using System.Dynamic;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
+using Magic.IndexedDb.Factories;
 using Magic.IndexedDb.Helpers;
 using Magic.IndexedDb.Models;
 using Magic.IndexedDb.SchemaAnnotations;

--- a/Magic.IndexedDb/Models/MagicException.cs
+++ b/Magic.IndexedDb/Models/MagicException.cs
@@ -1,0 +1,9 @@
+namespace Magic.IndexedDb.Models
+{
+
+	[Serializable]
+	public class MagicException : Exception
+	{
+		public MagicException(string message, Exception? inner = null) : base(message, inner) { }
+	}
+}


### PR DESCRIPTION
closes #29

I have refactored the `IMagicDbFactory`. It now has three methods:
- Get: To get a opened database with the given name
- OpenAsync: To dynamically open a database with the given `DbStore` (Or just work as `Get` if it is opened. A paramter `bool force` can determine the behavior.)
- GetRegisteredAsync: To open a database with the given name, respecting the registered `DbStore`s in the service provider (Or just work as `Get` if it is opened.)

The original `GetDbManagerAsync`s is attributed with `Obsolete`. But they still work as `GetRegisteredAsync`.