### PR TITLE
Invoke Async Refactor

### DIFF
--- a/Magic.IndexedDb/Extensions/MagicJsInvoke.cs
+++ b/Magic.IndexedDb/Extensions/MagicJsInvoke.cs
@@ -1,0 +1,74 @@
+﻿using Magic.IndexedDb.Helpers;
+using Magic.IndexedDb.Interfaces;
+using Magic.IndexedDb.Models;
+using Microsoft.JSInterop;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Magic.IndexedDb.Extensions
+{
+    internal class MagicJsInvoke
+    {
+        private readonly IJSObjectReference _jsModule;
+
+        public MagicJsInvoke(IJSObjectReference jsModule)
+        {
+            _jsModule = jsModule;
+        }
+
+        internal async Task<T?> MagicStreamJsAsync<T>(string functionName, CancellationToken token, params ITypedArgument[] args)
+        {
+            return await TrueMagicStreamJsAsync<T>(functionName, token, false, args);
+        }
+        private async Task<T?> TrueMagicStreamJsAsync<T>(string functionName, CancellationToken token, bool isVoid, params ITypedArgument[] args)
+        {
+            var settings = new MagicJsonSerializationSettings() { UseCamelCase = true };
+
+            var package = new MagicJsPackage
+            {
+                MethodName = functionName,
+                Parameters = MagicSerializationHelper.SerializeObjectsToString(args, settings),
+                IsVoid = isVoid
+            };
+
+#if DEBUG
+            package.IsDebug = true;
+#endif
+
+            using var stream = new MemoryStream();
+            await using (var writer = new StreamWriter(stream, leaveOpen: true))
+            {
+                await MagicSerializationHelper.SerializeObjectToStreamAsync(writer, package, settings);
+            }
+
+            // ✅ Immediately release reference to `package`
+            package = null;
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            stream.Position = 0;
+
+            var streamRef = new DotNetStreamReference(stream);
+
+            // Send to JS
+            var responseStreamRef = await _jsModule.InvokeAsync<IJSStreamReference>("streamedJsHandler", token, streamRef);
+
+            // 🚀 Convert the stream reference back to JSON in C#
+            await using var responseStream = await responseStreamRef.OpenReadStreamAsync(long.MaxValue, token);
+            using var reader = new StreamReader(responseStream);
+
+            string jsonResponse = await reader.ReadToEndAsync();
+            return MagicSerializationHelper.DeserializeObject<T>(jsonResponse, settings);
+        }
+
+        internal async Task MagicVoidStreamJsAsync(string functionName, CancellationToken token, params ITypedArgument[] args)
+        {
+            await TrueMagicStreamJsAsync<bool>(functionName, token, true, args);
+        }
+    }
+
+
+}

--- a/Magic.IndexedDb/Factories/MagicDbFactory.cs
+++ b/Magic.IndexedDb/Factories/MagicDbFactory.cs
@@ -15,7 +15,7 @@ namespace Magic.IndexedDb.Factories
             _serviceProvider = serviceProvider;
             this._jsRuntime = new(() => jSRuntime.InvokeAsync<IJSObjectReference>(
                 "import",
-                "./_content/Magic.IndexedDb/magicDB.js").AsTask());
+                "./_content/Magic.IndexedDb/magicDbMethods.js").AsTask());
         }
         public async ValueTask DisposeAsync()
         {

--- a/Magic.IndexedDb/Helpers/MagicSerializationHelper.cs
+++ b/Magic.IndexedDb/Helpers/MagicSerializationHelper.cs
@@ -1,6 +1,7 @@
 ﻿using Magic.IndexedDb.Interfaces;
 using Magic.IndexedDb.Models;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 
 namespace Magic.IndexedDb.Helpers
@@ -17,6 +18,11 @@ namespace Magic.IndexedDb.Helpers
             return objs.Select(arg => arg.SerializeToJsonElement(settings)).Cast<object>().ToArray();
         }
 
+        public static string[] SerializeObjectsToString(ITypedArgument[] objs, MagicJsonSerializationSettings? settings = null)
+        {
+            return objs.Select(arg => arg.SerializeToJsonString(settings)).ToArray();
+        }
+
         public static JsonElement SerializeObjectToJsonElement<T>(T value, MagicJsonSerializationSettings? settings = null)
         {
             if (settings == null)
@@ -31,6 +37,21 @@ namespace Magic.IndexedDb.Helpers
             // Convert the string to a JsonElement so that Blazor treats it as a structured object
             using JsonDocument doc = JsonDocument.Parse(jsonString);
             return doc.RootElement.Clone(); // Clone to prevent disposal issues
+        }
+
+        public static async Task SerializeObjectToStreamAsync<T>(StreamWriter writer, T value, MagicJsonSerializationSettings? settings = null)
+        {
+            if (settings == null)
+                settings = new MagicJsonSerializationSettings();
+
+            if (value == null)
+                throw new ArgumentNullException(nameof(value), "Object cannot be null");
+
+            var options = settings.GetOptionsWithResolver<T>();
+            string jsonString = JsonSerializer.Serialize(value, options); // Use your serializer
+
+            await writer.WriteAsync(jsonString);
+            await writer.FlushAsync();
         }
 
         public static string SerializeObject<T>(T value, MagicJsonSerializationSettings? settings = null)

--- a/Magic.IndexedDb/Helpers/PropertyMappingCache.cs
+++ b/Magic.IndexedDb/Helpers/PropertyMappingCache.cs
@@ -419,7 +419,8 @@ namespace Magic.IndexedDb.Helpers
                     property.IsDefined(typeof(MagicIndexAttribute), inherit: true),
                     property.IsDefined(typeof(MagicUniqueIndexAttribute), inherit: true),
                     property.IsDefined(typeof(MagicPrimaryKeyAttribute), inherit: true),
-                    property.IsDefined(typeof(MagicNotMappedAttribute), inherit: true)
+                    property.IsDefined(typeof(MagicNotMappedAttribute), inherit: true),
+                    property.IsDefined(typeof(MagicNameAttribute), inherit: true)
                 );
                 newMagicPropertyEntry.Add(magicEntry);
                 propertyEntries[propertyKey] = magicEntry; // Store property entry with string key

--- a/Magic.IndexedDb/Helpers/PropertyMappingCache.cs
+++ b/Magic.IndexedDb/Helpers/PropertyMappingCache.cs
@@ -397,6 +397,8 @@ namespace Magic.IndexedDb.Helpers
             // Initialize the dictionary for this type
             var propertyEntries = new Dictionary<string, MagicPropertyEntry>(StringComparer.OrdinalIgnoreCase);
 
+            bool hasMagicTableAttribute = type.IsDefined(typeof(MagicTableAttribute), inherit: true);
+
             List<MagicPropertyEntry> newMagicPropertyEntry = new List<MagicPropertyEntry>();
             foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy))
             {
@@ -420,7 +422,7 @@ namespace Magic.IndexedDb.Helpers
                     property.IsDefined(typeof(MagicUniqueIndexAttribute), inherit: true),
                     property.IsDefined(typeof(MagicPrimaryKeyAttribute), inherit: true),
                     property.IsDefined(typeof(MagicNotMappedAttribute), inherit: true),
-                    property.IsDefined(typeof(MagicNameAttribute), inherit: true)
+                    hasMagicTableAttribute || property.IsDefined(typeof(MagicNameAttribute), inherit: true)
                 );
                 newMagicPropertyEntry.Add(magicEntry);
                 propertyEntries[propertyKey] = magicEntry; // Store property entry with string key

--- a/Magic.IndexedDb/Interfaces/ITypedArgument.cs
+++ b/Magic.IndexedDb/Interfaces/ITypedArgument.cs
@@ -12,5 +12,6 @@ namespace Magic.IndexedDb.Interfaces
     {
         string Serialize(); // Still needed for some cases
         JsonElement SerializeToJsonElement(MagicJsonSerializationSettings? settings = null); // Ensures proper object passing
+        string SerializeToJsonString(MagicJsonSerializationSettings? settings = null);
     }
 }

--- a/Magic.IndexedDb/Models/MagicJsPackage.cs
+++ b/Magic.IndexedDb/Models/MagicJsPackage.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Magic.IndexedDb.Models
+{
+    internal class MagicJsPackage
+    {
+        public string MethodName { get; set; }
+        public string?[]? Parameters { get; set; }
+        public bool IsVoid { get; set; } = false;
+
+        public bool IsDebug { get; set; } = false;
+    }
+}

--- a/Magic.IndexedDb/Models/Structs/MagicPropertyEntry.cs
+++ b/Magic.IndexedDb/Models/Structs/MagicPropertyEntry.cs
@@ -18,7 +18,8 @@ namespace Magic.IndexedDb.Models
         /// Constructor for initializing MagicPropertyEntry while reducing memory footprint.
         /// </summary>
         public MagicPropertyEntry(PropertyInfo property, IColumnNamed? columnNamedAttribute,
-                                  bool indexed, bool uniqueIndex, bool primaryKey, bool notMapped)
+                                  bool indexed, bool uniqueIndex, bool primaryKey, bool notMapped, 
+                                  bool overrideNeverCamel = false)
         {
             Property = property;
             _columnNamedAttribute = columnNamedAttribute;
@@ -26,6 +27,7 @@ namespace Magic.IndexedDb.Models
             UniqueIndex = uniqueIndex;
             PrimaryKey = primaryKey;
             NotMapped = notMapped;
+            OverrideNeverCamel = overrideNeverCamel;
 
             IsComplexType = PropertyMappingCache.IsComplexType(property.PropertyType);
 
@@ -58,6 +60,8 @@ namespace Magic.IndexedDb.Models
 
         public object? DefaultValue { get; }
 
+        public bool OverrideNeverCamel { get; }
+
         /// <summary>
         /// If any Magic attribute was placed on a property. We never 
         /// camel case if that's the current json setting. These must stay 
@@ -67,7 +71,7 @@ namespace Magic.IndexedDb.Models
         {
             get
             {
-                if (PrimaryKey || UniqueIndex || Indexed)
+                if (PrimaryKey || UniqueIndex || Indexed || OverrideNeverCamel)
                     return true;
                 else
                     return false;

--- a/Magic.IndexedDb/Models/TypedArgument.cs
+++ b/Magic.IndexedDb/Models/TypedArgument.cs
@@ -27,6 +27,11 @@ namespace Magic.IndexedDb.Models
         {
             return MagicSerializationHelper.SerializeObjectToJsonElement(Value, settings);
         }
+
+        public string SerializeToJsonString(MagicJsonSerializationSettings? settings = null)
+        {
+            return MagicSerializationHelper.SerializeObject(Value, settings);
+        }
     }
 
 }

--- a/Magic.IndexedDb/SchemaAnnotations/MagicNameAttribute.cs
+++ b/Magic.IndexedDb/SchemaAnnotations/MagicNameAttribute.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Magic.IndexedDb.Interfaces;
+using Magic.IndexedDb.SchemaAnnotations;
+
+namespace Magic.IndexedDb.SchemaAnnotations
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class MagicNameAttribute : Attribute, IColumnNamed
+    {
+        public string ColumnName { get; }
+
+        public MagicNameAttribute(string columnName)
+        {
+            if (!string.IsNullOrWhiteSpace(columnName))
+            {
+                ColumnName = columnName;
+            }
+            else
+            {
+                throw new Exception("You have a MagicName attribute with no column name string provided!");
+            }
+        }
+    }
+}

--- a/Magic.IndexedDb/wwwroot/magicDbMethods.js
+++ b/Magic.IndexedDb/wwwroot/magicDbMethods.js
@@ -1,0 +1,63 @@
+"use strict";
+
+import * as MagicDbModule from './magicDB.js';
+
+// Console logging wrapper
+function consoleLog(message, isDebug) {
+    if (isDebug) {
+        console.log(message);
+    }
+}
+
+export async function streamedJsHandler(streamRef) {
+    consoleLog("Received streamRef", true);
+
+    if (!streamRef || typeof streamRef.arrayBuffer !== "function") {
+        console.error("Invalid stream reference received.");
+        return new Uint8Array();
+    }
+
+    try {
+        // Decode incoming data
+        let arrayBuffer = await streamRef.arrayBuffer();
+        let jsonText = new TextDecoder().decode(arrayBuffer);
+        arrayBuffer = null; // Free memory
+
+        // Parse the JSON payload
+        let parsedData = JSON.parse(jsonText);
+        jsonText = null; // Free memory
+
+        let { methodName, isVoid, parameters = [], isDebug } = parsedData;
+        consoleLog(`Parsed Data: ${JSON.stringify(parsedData)}`, isDebug);
+
+        // Deserialize parameters
+        let safeParameters = parameters.map(param => JSON.parse(param));
+        consoleLog(`Fixed Parameters (Deserialized): ${JSON.stringify(safeParameters)}`, isDebug);
+        parameters = null; // Free memory
+
+        // Free parsedData reference
+        parsedData = null;
+
+        if (typeof MagicDbModule[methodName] === "function") {
+            let result = await MagicDbModule[methodName](...safeParameters);
+            safeParameters = null; // Free memory after function call
+
+            if (isVoid) {
+                consoleLog(`Void method '${methodName}' executed successfully.`, isDebug);
+                return new Uint8Array(new TextEncoder().encode("true"));
+            }
+
+            // Stream response
+            let responseJson = JSON.stringify(result || {});
+            let encodedResponse = new TextEncoder().encode(responseJson);
+            responseJson = null; // Free memory
+            return new Uint8Array(encodedResponse);
+        } else {
+            console.error(`Method '${methodName}' not found in MagicDbModule.`);
+            return new Uint8Array(new TextEncoder().encode(JSON.stringify({ error: `Method '${methodName}' not found.` })));
+        }
+    } catch (error) {
+        console.error("Error handling streamed JS:", error);
+        return new Uint8Array(new TextEncoder().encode(JSON.stringify({ error: "Unexpected error in JS." })));
+    }
+}

--- a/Magic.IndexedDb/wwwroot/magicDbMethods.js
+++ b/Magic.IndexedDb/wwwroot/magicDbMethods.js
@@ -29,8 +29,6 @@ export async function streamedJsHandler(streamRef) {
 
         let { methodName, isVoid, parameters = [], isDebug } = parsedData;
         consoleLog(`Parsed Data: ${JSON.stringify(parsedData)}`, isDebug);
-
-        // Deserialize parameters
         let safeParameters = parameters.map(param => JSON.parse(param));
         consoleLog(`Fixed Parameters (Deserialized): ${JSON.stringify(safeParameters)}`, isDebug);
         parameters = null; // Free memory

--- a/TestWasm/Models/Person.cs
+++ b/TestWasm/Models/Person.cs
@@ -19,7 +19,7 @@ namespace TestWasm.Models
         [MagicIndex]
         public string Name { get; set; }
 
-        [MagicIndex("Age")]
+        [MagicName("Age")]
         public int _Age { get; set; }
 
         [MagicIndex]

--- a/TestWasm/Pages/Home.razor
+++ b/TestWasm/Pages/Home.razor
@@ -130,6 +130,7 @@
                 WhereExample = await manager.Where<Person>(x => x.Name.StartsWith("c", StringComparison.OrdinalIgnoreCase)
                 || x.Name.StartsWith("l", StringComparison.OrdinalIgnoreCase)
                 || x.Name.StartsWith("j", StringComparison.OrdinalIgnoreCase) && x._Age > 35
+                || x.Name.Contains("bo", StringComparison.OrdinalIgnoreCase)
                 ).OrderBy(x => x._Id).Skip(1).Execute();
 
                 /*

--- a/TestWasm/Pages/Home.razor
+++ b/TestWasm/Pages/Home.razor
@@ -51,8 +51,7 @@
             <th>ID</th>
             <th>Name</th>
             <th>Age</th>
-            <th>DecryptedSecret</th>
-            <th>Encrypted Secret</th>
+            <th>Not Mapped</th>
             <th>Access</th>
         </tr>
     </thead>
@@ -65,14 +64,10 @@
                 <td>@person._Age</td>
                 <td>
                     <div style="max-width: 400px; overflow-x: auto;">
-                        @person.SecretDecrypted
+                        @person.DoNotMapTest
                     </div>
                 </td>
-                <td>
-                    <div style="max-width: 200px; overflow-x: auto;">
-                        @person.Secret
-                    </div>
-                </td>
+
                 <td>@person.Access</td>
             </tr>
         }
@@ -83,12 +78,12 @@
 <br />
 <h3>Complex query capabilities!</h3>
 <pre>
-<code>
-<span style="color: #2A56C6;">await</span> manager.<span style="color: #2A56C6;">Where</span><span style="color: #A31515;">&lt;Person&gt;</span>(x =&gt; x.Name.<span style="color: #2A56C6;">StartsWith</span>(<span style="color: #A31515;">"c"</span>, <span style="color: #2A56C6;">StringComparison</span>.<span style="color: #2A56C6;">OrdinalIgnoreCase</span>)
-<span style="color: #2A56C6;">||</span> x.Name.<span style="color: #2A56C6;">StartsWith</span>(<span style="color: #A31515;">"l"</span>, <span style="color: #2A56C6;">StringComparison</span>.<span style="color: #2A56C6;">OrdinalIgnoreCase</span>)
-<span style="color: #2A56C6;">||</span> x.Name.<span style="color: #2A56C6;">StartsWith</span>(<span style="color: #A31515;">"j"</span>, <span style="color: #2A56C6;">StringComparison</span>.<span style="color: #2A56C6;">OrdinalIgnoreCase</span>) <span style="color: #2A56C6;">&amp;&amp;</span> x._Age <span style="color: #2A56C6;">&gt;</span> <span style="color: #2A56C6;">35</span>
-                    ).<span style="color: #2A56C6;">OrderBy</span>(x =&gt; x._Id).<span style="color: #2A56C6;">Skip</span>(<span style="color: #2A56C6;">1</span>).<span style="color: #2A56C6;">Execute</span>();
-</code>
+    <code>
+        <span style="color: #2A56C6;">await</span> manager.<span style="color: #2A56C6;">Where</span><span style="color: #A31515;">&lt;Person&gt;</span>(x =&gt; x.Name.<span style="color: #2A56C6;">StartsWith</span>(<span style="color: #A31515;">"c"</span>, <span style="color: #2A56C6;">StringComparison</span>.<span style="color: #2A56C6;">OrdinalIgnoreCase</span>)
+        <span style="color: #2A56C6;">||</span> x.Name.<span style="color: #2A56C6;">StartsWith</span>(<span style="color: #A31515;">"l"</span>, <span style="color: #2A56C6;">StringComparison</span>.<span style="color: #2A56C6;">OrdinalIgnoreCase</span>)
+        <span style="color: #2A56C6;">||</span> x.Name.<span style="color: #2A56C6;">StartsWith</span>(<span style="color: #A31515;">"j"</span>, <span style="color: #2A56C6;">StringComparison</span>.<span style="color: #2A56C6;">OrdinalIgnoreCase</span>) <span style="color: #2A56C6;">&amp;&amp;</span> x._Age <span style="color: #2A56C6;">&gt;</span> <span style="color: #2A56C6;">35</span>
+        ).<span style="color: #2A56C6;">OrderBy</span>(x =&gt; x._Id).<span style="color: #2A56C6;">Skip</span>(<span style="color: #2A56C6;">1</span>).<span style="color: #2A56C6;">Execute</span>();
+    </code>
 </pre>
 
 @foreach (Person person in WhereExample)
@@ -114,15 +109,15 @@
                 if (!(await manager.GetAllAsync<Person>()).Any())
                 {
                     Person[] persons = new Person[] {
-                        new Person { Name = "Zack", TestInt = 9, _Age = 45, GUIY = Guid.NewGuid(), Secret = "I buried treasure behind my house", Access=Person.Permissions.CanRead},
-                        new Person { Name = "Luna", TestInt = 9, _Age = 35, GUIY = Guid.NewGuid(), Secret = "Jerry is my husband and I had an affair with Bob.", Access = Person.Permissions.CanRead|Person.Permissions.CanWrite},
-                        new Person { Name = "Jerry", TestInt = 9, _Age = 35, GUIY = Guid.NewGuid(), Secret = "My wife is amazing", Access = Person.Permissions.CanRead|Person.Permissions.CanWrite|Person.Permissions.CanCreate},
-                        new Person { Name = "Jon", TestInt = 9, _Age = 37, GUIY = Guid.NewGuid(), Secret = "I black mail Luna for money because I know her secret", Access = Person.Permissions.CanRead},
-                        new Person { Name = "Jack", TestInt = 9, _Age = 37, GUIY = Guid.NewGuid(), Secret = "I have a drug problem", Access = Person.Permissions.CanRead|Person.Permissions.CanWrite},
-                        new Person { Name = "Cathy", TestInt = 9, _Age = 22, GUIY = Guid.NewGuid(), Secret = "I got away with reading Bobs diary.", Access = Person.Permissions.CanRead | Person.Permissions.CanWrite},
-                        new Person { Name = "Bob", TestInt = 3 , _Age = 69, GUIY = Guid.NewGuid(), Secret = "I caught Cathy reading my diary, but I'm too shy to confront her.", Access = Person.Permissions.CanRead },
-                        new Person { Name = "Alex", TestInt = 3 , _Age = 80, GUIY = Guid.NewGuid(), Secret = "I'm naked! But nobody can know!" }
-                };
+                        new Person { Name = "Zack", TestInt = 9, _Age = 45, GUIY = Guid.NewGuid(), DoNotMapTest = "I buried treasure behind my house", Access=Person.Permissions.CanRead},
+                        new Person { Name = "Luna", TestInt = 9, _Age = 35, GUIY = Guid.NewGuid(), DoNotMapTest = "Jerry is my husband and I had an affair with Bob.", Access = Person.Permissions.CanRead|Person.Permissions.CanWrite},
+                        new Person { Name = "Jerry", TestInt = 9, _Age = 35, GUIY = Guid.NewGuid(), DoNotMapTest = "My wife is amazing", Access = Person.Permissions.CanRead|Person.Permissions.CanWrite|Person.Permissions.CanCreate},
+                        new Person { Name = "Jon", TestInt = 9, _Age = 37, GUIY = Guid.NewGuid(), DoNotMapTest = "I black mail Luna for money because I know her secret", Access = Person.Permissions.CanRead},
+                        new Person { Name = "Jack", TestInt = 9, _Age = 37, GUIY = Guid.NewGuid(), DoNotMapTest = "I have a drug problem", Access = Person.Permissions.CanRead|Person.Permissions.CanWrite},
+                        new Person { Name = "Cathy", TestInt = 9, _Age = 22, GUIY = Guid.NewGuid(), DoNotMapTest = "I got away with reading Bobs diary.", Access = Person.Permissions.CanRead | Person.Permissions.CanWrite},
+                        new Person { Name = "Bob", TestInt = 3 , _Age = 69, GUIY = Guid.NewGuid(), DoNotMapTest = "I caught Cathy reading my diary, but I'm too shy to confront her.", Access = Person.Permissions.CanRead },
+                        new Person { Name = "Alex", TestInt = 3 , _Age = 80, GUIY = Guid.NewGuid(), DoNotMapTest = "I'm naked! But nobody can know!" }
+        };
                     await manager.AddRangeAsync(persons);
                 }
 
@@ -130,12 +125,7 @@
                 storageQuota = storageInfo.QuotaInMegabytes;
                 storageUsage = storageInfo.UsageInMegabytes;
 
-                var allPeopleDecrypted = await manager.GetAllAsync<Person>();
-                foreach (Person person in allPeopleDecrypted)
-                {
-                    person.SecretDecrypted = await manager.DecryptAsync(person.Secret);
-                    allPeople.Add(person);
-                }
+                allPeople = (await manager.GetAllAsync<Person>()).ToList();
 
                 WhereExample = await manager.Where<Person>(x => x.Name.StartsWith("c", StringComparison.OrdinalIgnoreCase)
                 || x.Name.StartsWith("l", StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
# Replaced Blazor Interop & Moved To Custom Communication
I've stripped away from Blazor their interop control over the library. No more double serializing and double deserializing. Instead "magicDbMethods.js" was introduced to dynamically call methods and replicate effectively what the modern Blazor Invoke Async already does. This removes the double unnecessary serializations.

Additionally I've moved everything to a streamed async communication to remove all C# to JS limits (aka no 16 MB limit on WASM nor 32 KB limit on server rendered / aka signalR). This introduces slight latency, but uncapped data transfer. The improvements in performance though showed in my results that the increase in latency is vastly outweighed by the removal of double deserialization, making this a net positive all around.

The only down side to this new version memory allocations that occurs at fractional seconds of memory processing and translation. This would only be an issue when data being transferred is somewhere around 70 MB to 100 MB (not fully sure yet). There's a few ideas I'm considering to remedy this. But the issue is inherent to Blazor itself and the fact it does **NOT** support JSON parse streaming, which is kind of exactly what the doctor ordered here. Without proper Json Parse streaming, options are limited. I will mull over this concept for a bit, but for now we're not just drastically faster, but bandwidth increased by ~4.4X minimum on Blazor WASM and 2,250X higher on SignalR server rendered blazor.

# JS Where Massive Improvement
The "where" method in JS has gotten a large boost in performance. instead of utilizing getTable and grabbing large amounts of items to be processed in memory. Now properly utilizing cursors, we properly translate the where statement to iterative row lookups. Making performance both faster and compressing memory use drastically.

| **Feature** | **Old Version** | **New Version** | **Loss?** |
|------------|---------------|---------------|---------|
| **Dynamically handles conditions** (`Equal`, `GreaterThan`, `LessThan`, etc.) | ✅ Yes | ✅ Yes | ❌ No |
| **Supports OR conditions** (`jsonQueries` with multiple conditions) | ✅ Yes | ✅ Yes (parallel execution) | ❌ No |
| **Supports sorting (`orderBy`, `orderByDescending`)** | ✅ Yes | ✅ Yes | ❌ No |
| **Supports pagination (`skip`, `take`, `takeLast`)** | ✅ Yes | ✅ Yes | ❌ No |
| **Supports indexed queries when possible** | ❌ No (forced in-memory filtering via `.and()`) | ✅ Yes (checks for indexed properties first) | ✅ **Improved** |
| **Supports cursor-based iteration for large datasets** | ❌ No (always loads everything into memory) | ✅ Yes (avoids memory bloat with `.each()`) | ✅ **Improved** |
| **Executes OR queries in parallel** | ❌ No (sequential execution) | ✅ Yes (`Promise.all()` for speed) | ✅ **Improved** |

## Review Notes
I'm going to manually just push this to Main later. Was just using this PR as documentation of changes and leaving it hanging for a day or 2 while I think over the changes. I'm also in the midst of altering the predicate builder system as well to be vastly more performant as well. Unsure if that'll be in this PR or another. This will also open the doors for us to create capabilities of more complex query capabilities with Joins and more. Well more like helpful illusions because IndexDB can't do that by default, but these are all very helpful new additions.

I'm also unsure if this PR will have this update or not, but I'm also trying to remove the "Execute" command entirely. It's unnecessary and should work like LINQ to SQL in which you can "ToList()" to get a list or you can work with the IEnumerable with deferred execution, or use that to make individual calls in a loop or anything else.

Though @yueyinqiu I don't see any where statement unit tests. We may want to make a to do list together at some point of unit tests we want to create. Because I just want to make sure I'm not making changes that breaks current functionality.

# Feature Requests
* Can use the new "**MagicName**" Attribute to rename columns without making it an index. https://github.com/magiccodingman/Magic.IndexedDb/issues/40

# Additional fixes
* Fixed complex query statements not translating
* Repaired a variety of query logic
* Fixed camel case non attributed properties. Camel case should **NEVER** apply to any property within an attributed Magic Table.

# People In IndexedDB!

| ID  | Name  | Age | Not Mapped | Access             |
|-----|-------|-----|------------|--------------------|
| 17  | Zack  | 45  |            | CanRead           |
| 18  | Luna  | 35  |            | CanRead, CanWrite |
| 19  | Jerry | 35  |            | CanRead, CanWrite, CanCreate |
| 20  | Jon   | 37  |            | CanRead           |
| 21  | Jack  | 37  |            | CanRead, CanWrite |
| 22  | Cathy | 22  |            | CanRead, CanWrite |
| 23  | Bob   | 69  |            | CanRead           |
| 24  | Alex  | 80  |            | None              |

---

## Complex Query Capabilities!

Within the table, "Id" is the primary key, "Name" is indexed, and "Age" is not an index at all, but utilizes cursors to query.

The following query is executed against IndexedDB using a LINQ-style syntax:

Here is your Markdown-formatted content for GitHub:  


# People In IndexedDB!

| ID  | Name  | Age | Not Mapped | Access             |
|-----|-------|-----|------------|--------------------|
| 17  | Zack  | 45  |            | CanRead           |
| 18  | Luna  | 35  |            | CanRead, CanWrite |
| 19  | Jerry | 35  |            | CanRead, CanWrite, CanCreate |
| 20  | Jon   | 37  |            | CanRead           |
| 21  | Jack  | 37  |            | CanRead, CanWrite |
| 22  | Cathy | 22  |            | CanRead, CanWrite |
| 23  | Bob   | 69  |            | CanRead           |
| 24  | Alex  | 80  |            | None              |



## Complex Query Capabilities!

The following query is executed against IndexedDB using a LINQ-style syntax:

```csharp
await manager.Where<Person>(
        x => x.Name.StartsWith("c", StringComparison.OrdinalIgnoreCase)
        || x.Name.StartsWith("l", StringComparison.OrdinalIgnoreCase)
        || x.Name.StartsWith("j", StringComparison.OrdinalIgnoreCase) && x._Age > 35
    ).OrderBy(x => x._Id).Skip(1).Execute();
```

### **Results**
The query returned the following matching people:

```
Name: Cathy - Age: 22
Name: Luna - Age: 35
Name: Jon - Age: 37
Name: Jack - Age: 37
```

---

## **How the Logic Works**
This query correctly filters and processes the dataset due to proper query translation and ordering:

1. **Filtering Logic:**
   - `Name.StartsWith("c")` → Matches **Cathy**.
   - `Name.StartsWith("l")` → Matches **Luna**.
   - `Name.StartsWith("j") && Age > 35` → Matches **Jon** and **Jack** (but **not Jerry**, because he is 35, not greater than 35).

2. **Ordering & Skipping:**
   - **Ordered by `ID`** in ascending order.
   - **Skipping the first result**, ensuring correct offset-based pagination.

3. **Final Matching Set:**
   - **Cathy** (`StartsWith("c")`).
   - **Luna** (`StartsWith("l")`).
   - **Jon** (`StartsWith("j")` and `Age > 35`).
   - **Jack** (`StartsWith("j")` and `Age > 35`).


This properly shows that we are now querying accordingly in a complex query situation.

# Big Feature Change
Due to this rework and repair. I implemented Cursors when items are not indexed. This means that you can iteratively look through rows and properly query even if it's not an index!