### PR TITLE
Use constructor annotated with jsonconstructor attribute

### DIFF
--- a/TestBase/Models/Person.cs
+++ b/TestBase/Models/Person.cs
@@ -13,6 +13,14 @@ public class Nested
 
 public class Person : MagicTableTool<Person>, IMagicTable<DbSets>
 {
+    public Person()
+    {
+    }
+
+    public Person(int? t)
+    {
+    }
+
     public List<IMagicCompoundIndex> GetCompoundIndexes() =>
         new List<IMagicCompoundIndex>() {
             CreateCompoundIndex(x => x.TestIntStable2, x => x.Name)

--- a/TestBase/Models/Person.cs
+++ b/TestBase/Models/Person.cs
@@ -1,4 +1,5 @@
-﻿using Magic.IndexedDb;
+﻿using System.Text.Json.Serialization;
+using Magic.IndexedDb;
 using Magic.IndexedDb.SchemaAnnotations;
 using TestBase.Repository;
 using static TestBase.Models.Person;
@@ -13,12 +14,15 @@ public class Nested
 
 public class Person : MagicTableTool<Person>, IMagicTable<DbSets>
 {
+    [JsonConstructor]
     public Person()
     {
+        DoNotMapTest2 = "Test";
     }
 
-    public Person(int? t)
+    public Person(int _Id)
     {
+        DoNotMapTest2 = _Id.ToString();
     }
 
     public List<IMagicCompoundIndex> GetCompoundIndexes() =>

--- a/TestServer/TestServer/Components/Pages/Home.razor
+++ b/TestServer/TestServer/Components/Pages/Home.razor
@@ -46,9 +46,6 @@
 <PageTitle>Example</PageTitle>
 
 <h3>Unit Tests</h3>
-
-@(System.Text.Json.JsonSerializer.Serialize(new Person()))
-
 @foreach (var (testName, response, countResults) in TestResults)
 {
     <div>

--- a/TestServer/TestServer/Components/Pages/Home.razor
+++ b/TestServer/TestServer/Components/Pages/Home.razor
@@ -46,6 +46,9 @@
 <PageTitle>Example</PageTitle>
 
 <h3>Unit Tests</h3>
+
+@(System.Text.Json.JsonSerializer.Serialize(new Person()))
+
 @foreach (var (testName, response, countResults) in TestResults)
 {
     <div>


### PR DESCRIPTION
Fixes #101, Class properties are not instantiated when there is a constructor with parameter. In this way the data from the indexeddb is deserialized while giving the option to do contructor time operations on a select amount of properties without having to specify all of them. Fields this way will still be overwritten by the custon deconstructor, but it can be helpfull to do operations on nonmapped properties in the constructor. 


